### PR TITLE
Hotfix for error if one player is in space

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/StorageComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/StorageComponent_Patch.cs
@@ -50,7 +50,7 @@ namespace NebulaPatcher.Patches.Dynamic
         [HarmonyPatch(nameof(StorageComponent.SetBans))]
         public static void SetBans_Postfix(StorageComponent __instance, int _bans)
         {
-            if (Multiplayer.IsActive && !Multiplayer.Session.Storage.IsIncomingRequest)
+            if (Multiplayer.IsActive && !Multiplayer.Session.Storage.IsIncomingRequest && GameMain.data.localPlanet != null)
             {
                 HandleUserInteraction(__instance, new StorageSyncSetBansPacket(__instance.id, GameMain.data.localPlanet.id, _bans));
             }


### PR DESCRIPTION
Sometimes if one player is in space, the others will also have localPlanet as null for some reason. 
Needs further investigation..